### PR TITLE
fix 'Event' object has no attribute 'id' #23

### DIFF
--- a/src/sentry_dingtalk_xz/plugin.py
+++ b/src/sentry_dingtalk_xz/plugin.py
@@ -56,7 +56,7 @@ class DingTalkPlugin(NotificationPlugin):
                     message=event.message,
                     url=u'{url}events/{id}/'.format(
                         url=group.get_absolute_url(),
-                        id=event.id
+                        id=event.event_id
                     ),
                 )
             }


### PR DESCRIPTION
FIXED 'Event' object has no attribute 'id' #23